### PR TITLE
Scale the grid

### DIFF
--- a/battle_map_tv/aoe.py
+++ b/battle_map_tv/aoe.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 class AreaOfEffectManager:
-    def __init__(self, window: "ImageWindow"):
+    def __init__(self, window: "ImageWindow", grid: Grid):
         self.window = window
         self.scene = window.scene()
         self._store: List[BaseShape] = []
@@ -36,7 +36,7 @@ class AreaOfEffectManager:
         self.start_point: Optional[Tuple[int, int]] = None
         self.temp_obj: Optional[BaseShape] = None
         self.callback: Optional[Callable] = None
-        self.grid: Optional[Grid] = None
+        self.grid = grid
         self._previous_size: Optional[float] = None
 
     def wait_for(self, shape: str, callback: Callable):
@@ -49,7 +49,6 @@ class AreaOfEffectManager:
         self.waiting_for = None
         self.start_point = None
         self.callback = None
-        self.grid = None
 
     def clear_all(self):
         for shape_obj in self._store:
@@ -98,7 +97,6 @@ class AreaOfEffectManager:
         shape_cls = shapes_dict[self.waiting_for]
         x1, y1 = self.start_point
         if self.snap_to_grid:
-            self.grid = Grid(window=self.window)
             x1, y1 = self.grid.snap_to_grid(x=x1, y=y1)
         shape_obj = shape_cls(
             x1=x1,

--- a/battle_map_tv/aoe_rasterization.py
+++ b/battle_map_tv/aoe_rasterization.py
@@ -10,7 +10,7 @@ from battle_map_tv.grid import Grid
 def circle_to_polygon(
     x_center: int, y_center: int, radius: int, grid: Grid
 ) -> List[Tuple[int, int]]:
-    delta = grid.pixels_per_inch_mean
+    delta = grid.pixels_per_square
     radius = radius - radius % delta
     if radius < delta:
         return []
@@ -86,7 +86,7 @@ class CircleEdges:
 def rasterize_cone(x1: int, y1: int, size: int, angle: float, grid: Grid) -> List[Tuple[int, int]]:
     if size == 0:
         return []
-    delta = grid.pixels_per_inch_mean
+    delta = grid.pixels_per_square
     point_0 = (x1, y1)
     point_1, point_2 = calculate_cone_points(point_0=point_0, size=size, angle=angle)
     x_points, y_points = rasterize_cone_by_pixels(

--- a/battle_map_tv/global_vars.py
+++ b/battle_map_tv/global_vars.py
@@ -1,3 +1,0 @@
-from typing import Optional, Tuple
-
-screen_size_mm: Optional[Tuple[int, int]] = None

--- a/battle_map_tv/grid.py
+++ b/battle_map_tv/grid.py
@@ -6,6 +6,7 @@ from PySide6.QtGui import QPen, QColor
 from PySide6.QtWidgets import QGraphicsView, QGraphicsItemGroup, QWidget
 
 from battle_map_tv.utils import size_to_tuple
+from storage import get_from_storage, StorageKeys, set_in_storage
 
 mm_to_inch = 0.03937007874
 
@@ -14,7 +15,7 @@ class Grid:
     def __init__(self, window: QWidget):
         self.window = window
 
-        self.pixels_per_square: int = 40
+        self.pixels_per_square: int = get_from_storage(StorageKeys.pixels_per_square, default=40)
         self.n_lines: Tuple[int, int]
         self.offset: Tuple[int, int]
 
@@ -40,8 +41,8 @@ class Grid:
         )
 
     def set_size(self, value: int):
-        """Value is in pixels"""
         self.pixels_per_square = value
+        set_in_storage(StorageKeys.pixels_per_square, value)
         self.calculate()
 
     def get_lines(self, axis: int) -> List[Tuple[int, int, int, int]]:

--- a/battle_map_tv/grid.py
+++ b/battle_map_tv/grid.py
@@ -5,7 +5,6 @@ from PySide6.QtCore import QLineF
 from PySide6.QtGui import QPen, QColor
 from PySide6.QtWidgets import QGraphicsView, QGraphicsItemGroup, QWidget
 
-from battle_map_tv import global_vars
 from battle_map_tv.utils import size_to_tuple
 
 mm_to_inch = 0.03937007874
@@ -13,73 +12,81 @@ mm_to_inch = 0.03937007874
 
 class Grid:
     def __init__(self, window: QWidget):
-        screen_size_mm = global_vars.screen_size_mm
-        screen_size_px = size_to_tuple(window.screen().size())
-        self.window_size_px = size_to_tuple(window.size())
+        self.window = window
 
-        if screen_size_mm is not None:
-            self.pixels_per_inch = self._as_tuple(
-                int(screen_size_px[i] / screen_size_mm[i] / mm_to_inch) for i in range(2)
-            )
-        else:
-            self.pixels_per_inch = (60, 60)
-        self.pixels_per_inch_mean = round(sum(self.pixels_per_inch) / 2)
+        self.pixels_per_square: int = 40
+        self.n_lines: Tuple[int, int]
+        self.offset: Tuple[int, int]
 
-        self.n_lines = self._as_tuple(
-            math.ceil(self.window_size_px[i] / self.pixels_per_inch[i]) for i in range(2)
-        )
-
-        self.offset = self._as_tuple(
-            int((self.window_size_px[i] - ((self.n_lines[i] - 1) * self.pixels_per_inch[i])) / 2)
-            for i in range(2)
-        )
+        self.calculate()
 
     @staticmethod
     def _as_tuple(generator) -> Tuple[int, int]:
         values = list(generator)
         return values[0], values[1]
 
+    @property
+    def window_size_px(self):
+        return size_to_tuple(self.window.size())
+
+    def calculate(self):
+        self.n_lines = self._as_tuple(
+            math.ceil(self.window_size_px[i] / self.pixels_per_square) for i in range(2)
+        )
+
+        self.offset = self._as_tuple(
+            int(self.window_size_px[i] / 2 - self.pixels_per_square * int(self.n_lines[i] / 2))
+            for i in range(2)
+        )
+
+    def set_size(self, value: int):
+        """Value is in pixels"""
+        self.pixels_per_square = value
+        self.calculate()
+
     def get_lines(self, axis: int) -> List[Tuple[int, int, int, int]]:
         assert axis in (0, 1)
         lines = []
         for i in range(self.n_lines[axis]):
-            start_point = (
-                i * self.pixels_per_inch[axis] + self.offset[axis],
-                0,
-            )[:: 1 if axis == 0 else -1]
+            start_point = (i * self.pixels_per_square + self.offset[axis], 0)
             end_point = (
-                i * self.pixels_per_inch[axis] + self.offset[axis],
+                i * self.pixels_per_square + self.offset[axis],
                 self.window_size_px[1 if axis == 0 else 0],
-            )[:: 1 if axis == 0 else -1]
+            )
+            if axis == 1:
+                start_point = start_point[::-1]
+                end_point = end_point[::-1]
             lines.append((start_point[0], start_point[1], end_point[0], end_point[1]))
         return lines
 
     def snap_to_grid(self, x: int, y: int) -> Tuple[int, int]:
         point = (x, y)
         return self._as_tuple(
-            self._snap(p=point[i], offset=self.offset[i], ppi=self.pixels_per_inch[i], divide_by=2)
+            self._snap(p=point[i], offset=self.offset[i], ppi=self.pixels_per_square, divide_by=2)
             for i in range(2)
         )
 
     def normalize_size(self, size: float) -> int:
-        return self._snap(p=size, offset=0, ppi=self.pixels_per_inch_mean, divide_by=1)
+        return self._snap(p=size, offset=0, ppi=self.pixels_per_square, divide_by=1)
 
     @staticmethod
     def _snap(p: float, offset: int, ppi: int, divide_by: int) -> int:
         return int(round(divide_by * (p - offset) / ppi) * ppi / divide_by + offset)
 
     def pixels_to_feet(self, value: float) -> float:
-        return 5 * value / self.pixels_per_inch_mean
+        return 5 * value / self.pixels_per_square
 
 
 class GridOverlay:
     def __init__(
         self,
         window,
+        grid: Grid,
         opacity: int,
     ):
         self.window = window
         self.scene = window.scene()
+        self.grid = grid
         self.opacity = opacity
 
         self.view = QGraphicsView()
@@ -101,13 +108,11 @@ class GridOverlay:
         self.group.setZValue(1)
         self.scene.addItem(self.group)
 
-        grid = Grid(window=self.window)
-
         pen = QPen()
         pen.setWidth(1)
         pen.setColor(QColor(255, 255, 255, self.opacity))
 
         for axis in (0, 1):
-            for line_coordinates in grid.get_lines(axis=axis):
+            for line_coordinates in self.grid.get_lines(axis=axis):
                 line = self.scene.addLine(QLineF(*line_coordinates), pen)
                 self.group.addToGroup(line)

--- a/battle_map_tv/grid.py
+++ b/battle_map_tv/grid.py
@@ -8,8 +8,6 @@ from PySide6.QtWidgets import QGraphicsView, QGraphicsItemGroup, QWidget
 from battle_map_tv.utils import size_to_tuple
 from storage import get_from_storage, StorageKeys, set_in_storage
 
-mm_to_inch = 0.03937007874
-
 
 class Grid:
     def __init__(self, window: QWidget):

--- a/battle_map_tv/image.py
+++ b/battle_map_tv/image.py
@@ -5,7 +5,7 @@ from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QGraphicsPixmapItem, QGraphicsScene
 
 from battle_map_tv.events import global_event_dispatcher, EventKeys
-from battle_map_tv.grid import mm_to_inch
+from battle_map_tv.grid import Grid
 from battle_map_tv.scale_detection import find_image_scale
 from battle_map_tv.storage import (
     set_image_in_storage,
@@ -13,7 +13,6 @@ from battle_map_tv.storage import (
     get_image_from_storage,
     set_in_storage,
     StorageKeys,
-    get_from_storage,
 )
 
 
@@ -129,14 +128,7 @@ class Image:
     def scale(self, value: float):
         self.pixmap_item.set_scale(value)
 
-    def autoscale(self):
-        try:
-            screen_size_mm = get_from_storage(StorageKeys.screen_size_mm)
-        except KeyError:
-            return
-
-        screen_px_per_mm = self.scene.views()[0].screen().size().width() / screen_size_mm[0]
-        px_per_inch = find_image_scale(self.filepath)
-        px_per_mm = px_per_inch * mm_to_inch
-        scale = screen_px_per_mm / px_per_mm
+    def autoscale(self, grid: Grid):
+        image_px_per_square = find_image_scale(self.filepath)
+        scale = grid.pixels_per_square / image_px_per_square
         self.scale(scale)

--- a/battle_map_tv/initiative.py
+++ b/battle_map_tv/initiative.py
@@ -10,10 +10,7 @@ from battle_map_tv.storage import get_from_storage, StorageKeys, set_in_storage
 class InitiativeOverlayManager:
     def __init__(self, scene):
         self.scene = scene
-        try:
-            self.font_size = get_from_storage(StorageKeys.initiative_font_size)
-        except KeyError:
-            self.font_size = 20
+        self.font_size = get_from_storage(StorageKeys.initiative_font_size, default=20)
         self.overlays = []
 
     def create(self, text: str):

--- a/battle_map_tv/storage.py
+++ b/battle_map_tv/storage.py
@@ -25,6 +25,7 @@ def _dump(data: Dict[str, Any]):
 
 
 class StorageKeys(Enum):
+    pixels_per_square = "pixels_per_square"
     previous_image = "previous_image"
     initiative_font_size = "initiative_font_size"
     thumbnail_0 = "thumbnail_0"
@@ -33,15 +34,18 @@ class StorageKeys(Enum):
     thumbnail_3 = "thumbnail_3"
 
 
-def get_from_storage(key: StorageKeys, optional: bool = False):
+class Undefined:
+    pass
+
+
+def get_from_storage(key: StorageKeys, default=Undefined):
     data = _load()
     try:
         return data[key.value]
     except KeyError:
-        if optional:
-            return None
-        else:
+        if default is Undefined:
             raise
+        return default
 
 
 def set_in_storage(key: StorageKeys, value: Any):

--- a/battle_map_tv/storage.py
+++ b/battle_map_tv/storage.py
@@ -25,7 +25,6 @@ def _dump(data: Dict[str, Any]):
 
 
 class StorageKeys(Enum):
-    screen_size_mm = "screen_size_mm"
     previous_image = "previous_image"
     initiative_font_size = "initiative_font_size"
     thumbnail_0 = "thumbnail_0"

--- a/battle_map_tv/window_gui.py
+++ b/battle_map_tv/window_gui.py
@@ -176,7 +176,9 @@ class GuiWindow(QWidget):
             if self.image_window.grid_overlay is not None:
                 self.image_window.grid_overlay.reset()
 
-        slider_grid_size = StyledSlider(lower=10, upper=400, default=40)
+        slider_grid_size = StyledSlider(
+            lower=10, upper=400, default=self.image_window.grid.pixels_per_square
+        )
         slider_grid_size.valueChanged.connect(slider_grid_size_callback)
         container.addWidget(slider_grid_size)
 

--- a/battle_map_tv/window_gui.py
+++ b/battle_map_tv/window_gui.py
@@ -130,7 +130,7 @@ class GuiWindow(QWidget):
 
         def button_autoscale_callback():
             if self.image_window.image is not None:
-                self.image_window.image.autoscale()
+                self.image_window.image.autoscale(grid=self.image_window.grid)
 
         button = StyledButton("Autoscale")
         button.clicked.connect(button_autoscale_callback)

--- a/battle_map_tv/window_image.py
+++ b/battle_map_tv/window_image.py
@@ -5,7 +5,7 @@ from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QGraphicsView, QGraphicsScene
 
 from battle_map_tv.aoe import AreaOfEffectManager
-from battle_map_tv.grid import GridOverlay
+from battle_map_tv.grid import GridOverlay, Grid
 from battle_map_tv.image import Image
 from battle_map_tv.initiative import InitiativeOverlayManager
 from battle_map_tv.storage import get_from_storage, StorageKeys
@@ -32,9 +32,10 @@ class ImageWindow(QGraphicsView):
         self.setScene(scene)
 
         self.image: Optional[Image] = None
+        self.grid = Grid(window=self)
         self.grid_overlay: Optional[GridOverlay] = None
         self.initiative_overlay_manager = InitiativeOverlayManager(scene=scene)
-        self.area_of_effect_manager = AreaOfEffectManager(window=self)
+        self.area_of_effect_manager = AreaOfEffectManager(window=self, grid=self.grid)
 
     def toggle_fullscreen(self):
         if self.isFullScreen():
@@ -67,7 +68,7 @@ class ImageWindow(QGraphicsView):
     def add_grid(self, opacity: int):
         if self.grid_overlay is not None:
             self.remove_grid()
-        self.grid_overlay = GridOverlay(window=self, opacity=opacity)
+        self.grid_overlay = GridOverlay(window=self, grid=self.grid, opacity=opacity)
 
     def update_screen_size_mm(self):
         if self.grid_overlay is not None:
@@ -114,6 +115,7 @@ class ImageWindow(QGraphicsView):
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self.scene().setSceneRect(0, 0, self.size().width(), self.size().height())
+        self.grid.calculate()
         if self.grid_overlay is not None:
             self.grid_overlay.reset()
 


### PR DESCRIPTION
No longer work with a screen size in millimeters. Instead allow scaling the grid, so users are more flexible what size they want. And they don't have to measure their screens.