### PR TITLE
Grid color: black, white, opacity

### DIFF
--- a/battle_map_tv/grid.py
+++ b/battle_map_tv/grid.py
@@ -76,24 +76,38 @@ class Grid:
         return 5 * value / self.pixels_per_square
 
 
+class GridOverlayColor:
+    min = -100
+    max = 100
+    default = 70
+
+    @classmethod
+    def get_color(cls, value: int) -> QColor:
+        opacity = int(255 * abs(value) / 100)
+        if value < 0:
+            return QColor(0, 0, 0, opacity)
+        else:
+            return QColor(255, 255, 255, opacity)
+
+
 class GridOverlay:
     def __init__(
         self,
         window,
         grid: Grid,
-        opacity: int,
+        color_value: int,
     ):
         self.window = window
         self.scene = window.scene()
         self.grid = grid
-        self.opacity = opacity
+        self.color_value = color_value
 
         self.view = QGraphicsView()
         self.group: Optional[QGraphicsItemGroup] = None
         self.reset()
 
-    def update_opacity(self, opacity: int):
-        self.opacity = opacity
+    def update_color(self, value: int):
+        self.color_value = value
         self.reset()
 
     def delete(self):
@@ -109,7 +123,7 @@ class GridOverlay:
 
         pen = QPen()
         pen.setWidth(1)
-        pen.setColor(QColor(255, 255, 255, self.opacity))
+        pen.setColor(GridOverlayColor.get_color(self.color_value))
 
         for axis in (0, 1):
             for line_coordinates in self.grid.get_lines(axis=axis):

--- a/battle_map_tv/grid.py
+++ b/battle_map_tv/grid.py
@@ -77,17 +77,14 @@ class Grid:
 
 
 class GridOverlayColor:
-    min = -100
-    max = 100
-    default = 70
+    min = -255
+    max = 255
+    default = 200
 
     @classmethod
     def get_color(cls, value: int) -> QColor:
-        opacity = int(255 * abs(value) / 100)
-        if value < 0:
-            return QColor(0, 0, 0, opacity)
-        else:
-            return QColor(255, 255, 255, opacity)
+        c = 0 if value < 0 else 255
+        return QColor(c, c, c, abs(value))
 
 
 class GridOverlay:

--- a/battle_map_tv/window_gui.py
+++ b/battle_map_tv/window_gui.py
@@ -21,6 +21,7 @@ from battle_map_tv.ui_elements import (
     FixedRowGridLayout,
 )
 from battle_map_tv.window_image import ImageWindow
+from grid import GridOverlayColor
 
 
 class GuiWindow(QWidget):
@@ -182,31 +183,24 @@ class GuiWindow(QWidget):
         slider_grid_size.valueChanged.connect(slider_grid_size_callback)
         container.addWidget(slider_grid_size)
 
-        slider_factor = 100
-
-        def slider_grid_opacity_callback(value: int):
+        def slider_grid_color_callback(value: int):
             if self.image_window.grid_overlay is not None:
-                self.image_window.grid_overlay.update_opacity(normalize_slider_value(value))
+                self.image_window.grid_overlay.update_color(value)
 
-        def normalize_slider_value(value: int) -> int:
-            """Normalize a value between 0 and 100 to 0 and 255"""
-            return int(255 * value / slider_factor)
-
-        label = QLabel("Grid opacity")
+        label = QLabel("Grid color")
         container.addWidget(label)
 
-        slider_grid_opacity = StyledSlider(
-            lower=0, upper=slider_factor, default=int(0.7 * slider_factor)
+        slider_grid_color = StyledSlider(
+            lower=GridOverlayColor.min, upper=GridOverlayColor.max, default=GridOverlayColor.default
         )
-        slider_grid_opacity.valueChanged.connect(slider_grid_opacity_callback)
-        container.addWidget(slider_grid_opacity)
+        slider_grid_color.valueChanged.connect(slider_grid_color_callback)
+        container.addWidget(slider_grid_color)
 
         def toggle_grid_callback(value: bool):
             if self.image_window.grid_overlay is not None:
                 self.image_window.remove_grid()
             else:
-                opacity = normalize_slider_value(slider_grid_opacity.value())
-                self.image_window.add_grid(opacity=opacity)
+                self.image_window.add_grid(color_value=slider_grid_color.value())
             self.image_window.toggle_snap_to_grid_area_of_effect(enable=value)
             global_event_dispatcher.dispatch_event(EventKeys.toggle_grid, value)
 

--- a/battle_map_tv/window_image.py
+++ b/battle_map_tv/window_image.py
@@ -65,10 +65,10 @@ class ImageWindow(QGraphicsView):
             self.remove_image()
             self.add_image(image_path=previous_image)
 
-    def add_grid(self, opacity: int):
+    def add_grid(self, color_value: int):
         if self.grid_overlay is not None:
             self.remove_grid()
-        self.grid_overlay = GridOverlay(window=self, grid=self.grid, opacity=opacity)
+        self.grid_overlay = GridOverlay(window=self, grid=self.grid, color_value=color_value)
 
     def update_screen_size_mm(self):
         if self.grid_overlay is not None:


### PR DESCRIPTION
Instead of a white grid with an opacity slider, allow sliding between black and white with fully opaque in between.