### PR TITLE
Double scale sliders

### DIFF
--- a/battle_map_tv/elements/dual_scale_slider.py
+++ b/battle_map_tv/elements/dual_scale_slider.py
@@ -20,37 +20,30 @@ class DualScaleSlider(QWidget):
         scale_layout.addWidget(self.scale_edit)
         scale_layout.addStretch()
 
-        coarse_layout = QHBoxLayout()
         coarse_label = QLabel("Coarse")
         self.coarse_slider = StyledSlider(
             lower=1,
             upper=self.max_scale * self.factor_coarse,
             default=self.factor_coarse,
         )
-        coarse_layout.addWidget(coarse_label)
-        coarse_layout.addWidget(self.coarse_slider)
-
-        fine_layout = QHBoxLayout()
         fine_label = QLabel("Fine")
         self.fine_slider = StyledSlider(
             lower=-self.factor_fine // 10,
             upper=self.factor_fine // 10,
             default=0,
         )
-        fine_layout.addWidget(fine_label)
-        fine_layout.addWidget(self.fine_slider)
 
-        grid_layout = QGridLayout()
-        grid_layout.addWidget(coarse_label, 0, 0)
-        grid_layout.addWidget(self.coarse_slider, 0, 1)
-        grid_layout.addWidget(fine_label, 1, 0)
-        grid_layout.addWidget(self.fine_slider, 1, 1)
-        grid_layout.setColumnStretch(1, 1)
+        sliders_labels_layout = QGridLayout()
+        sliders_labels_layout.addWidget(coarse_label, 0, 0)
+        sliders_labels_layout.addWidget(self.coarse_slider, 0, 1)
+        sliders_labels_layout.addWidget(fine_label, 1, 0)
+        sliders_labels_layout.addWidget(self.fine_slider, 1, 1)
+        sliders_labels_layout.setColumnStretch(1, 1)
 
         main_layout = QVBoxLayout(self)
         main_layout.addLayout(scale_layout)
         main_layout.addSpacing(9)
-        main_layout.addLayout(grid_layout)
+        main_layout.addLayout(sliders_labels_layout)
 
         self.coarse_slider.valueChanged.connect(self.update_scale_from_sliders)
         self.fine_slider.valueChanged.connect(self.update_scale_from_sliders)

--- a/battle_map_tv/elements/dual_scale_slider.py
+++ b/battle_map_tv/elements/dual_scale_slider.py
@@ -72,8 +72,7 @@ class DualScaleSlider(QWidget):
             value = float(text)
         except ValueError:
             return
-        value = self._value_bounds(value)
-        self.scale_changed.emit(value)
+        self.update_sliders_from_scale(value)
 
     def update_sliders_from_scale(self, value: float):
         coarse_value = round(self.factor_coarse * value)

--- a/battle_map_tv/elements/dual_scale_slider.py
+++ b/battle_map_tv/elements/dual_scale_slider.py
@@ -1,0 +1,66 @@
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QHBoxLayout, QGridLayout
+from PySide6.QtCore import Signal
+
+from ui_elements import StyledSlider, StyledLineEdit
+
+
+class DualScaleSlider(QWidget):
+    scale_changed = Signal(float)
+
+    def __init__(self):
+        super().__init__()
+
+        scale_layout = QHBoxLayout()
+        scale_layout.addWidget(QLabel("Image scale:"))
+        scale_layout.addSpacing(5)
+        self.scale_edit = StyledLineEdit(max_length=10, width=120, value="1.00000")
+        scale_layout.addWidget(self.scale_edit)
+        scale_layout.addStretch()
+
+        coarse_layout = QHBoxLayout()
+        coarse_label = QLabel("Coarse")
+        self.coarse_slider = StyledSlider(lower=1, upper=4000, default=1000)
+        coarse_layout.addWidget(coarse_label)
+        coarse_layout.addWidget(self.coarse_slider)
+
+        fine_layout = QHBoxLayout()
+        fine_label = QLabel("Fine")
+        self.fine_slider = StyledSlider(lower=-10000, upper=10000, default=0)
+        fine_layout.addWidget(fine_label)
+        fine_layout.addWidget(self.fine_slider)
+
+        grid_layout = QGridLayout()
+        grid_layout.addWidget(coarse_label, 0, 0)
+        grid_layout.addWidget(self.coarse_slider, 0, 1)
+        grid_layout.addWidget(fine_label, 1, 0)
+        grid_layout.addWidget(self.fine_slider, 1, 1)
+        grid_layout.setColumnStretch(1, 1)
+
+        main_layout = QVBoxLayout(self)
+        main_layout.addLayout(scale_layout)
+        main_layout.addSpacing(9)
+        main_layout.addLayout(grid_layout)
+
+        self.coarse_slider.valueChanged.connect(self.update_scale_from_sliders)
+        self.fine_slider.valueChanged.connect(self.update_scale_from_sliders)
+        self.scale_edit.editingFinished.connect(self.update_scale_from_edit)
+
+    def update_scale_from_sliders(self):
+        coarse_value = self.coarse_slider.value() / 1000
+        fine_value = self.fine_slider.value() / 100000
+        total_scale = coarse_value + fine_value
+
+        self.scale_edit.setText(f"{total_scale:.5f}")
+
+        self.scale_changed.emit(total_scale)
+
+    def update_scale_from_edit(self):
+        text = self.scale_edit.text()
+        try:
+            value = float(text)
+        except ValueError:
+            return
+        self.scale_changed.emit(value)
+
+    def update_values(self, value: float):
+        self.scale_edit.setText(f"{value:.5f}")

--- a/battle_map_tv/elements/dual_scale_slider.py
+++ b/battle_map_tv/elements/dual_scale_slider.py
@@ -22,13 +22,21 @@ class DualScaleSlider(QWidget):
 
         coarse_layout = QHBoxLayout()
         coarse_label = QLabel("Coarse")
-        self.coarse_slider = StyledSlider(lower=1, upper=self.max_scale * self.factor_coarse, default=self.factor_coarse)
+        self.coarse_slider = StyledSlider(
+            lower=1,
+            upper=self.max_scale * self.factor_coarse,
+            default=self.factor_coarse,
+        )
         coarse_layout.addWidget(coarse_label)
         coarse_layout.addWidget(self.coarse_slider)
 
         fine_layout = QHBoxLayout()
         fine_label = QLabel("Fine")
-        self.fine_slider = StyledSlider(lower=-self.factor_fine // 10, upper=self.factor_fine // 10, default=0)
+        self.fine_slider = StyledSlider(
+            lower=-self.factor_fine // 10,
+            upper=self.factor_fine // 10,
+            default=0,
+        )
         fine_layout.addWidget(fine_label)
         fine_layout.addWidget(self.fine_slider)
 

--- a/battle_map_tv/image.py
+++ b/battle_map_tv/image.py
@@ -28,7 +28,6 @@ class CustomGraphicsPixmapItem(QGraphicsPixmapItem):
     def wheelEvent(self, event):
         value = self.scale() + event.delta() / 1500
         self.set_scale(value)
-        global_event_dispatcher.dispatch_event(EventKeys.change_scale, value)
 
     def mouseReleaseEvent(self, event):
         super().mouseReleaseEvent(event)
@@ -48,8 +47,10 @@ class CustomGraphicsPixmapItem(QGraphicsPixmapItem):
         )
         set_image_in_storage(self.image_filename, ImageKeys.position, position)
 
-    def set_scale(self, value: float):
+    def set_scale(self, value: float, dispatch_event: bool = True):
         self.setScale(value)
+        if dispatch_event:
+            global_event_dispatcher.dispatch_event(EventKeys.change_scale, value)
         set_image_in_storage(self.image_filename, ImageKeys.scale, value)
 
 
@@ -97,7 +98,6 @@ class Image:
                 self.scale(scale_fit_image)
         else:
             self.scale(scale)
-            global_event_dispatcher.dispatch_event(EventKeys.change_scale, scale)
 
         try:
             position = get_image_from_storage(
@@ -121,8 +121,8 @@ class Image:
         self.pixmap_item.setRotation(self.rotation)
         set_image_in_storage(self.image_filename, ImageKeys.rotation, self.rotation)
 
-    def scale(self, value: float):
-        self.pixmap_item.set_scale(value)
+    def scale(self, value: float, dispatch_event: bool = True):
+        self.pixmap_item.set_scale(value, dispatch_event=dispatch_event)
 
     def autoscale(self, grid: Grid):
         image_px_per_square = find_image_scale(self.filepath)

--- a/battle_map_tv/image.py
+++ b/battle_map_tv/image.py
@@ -83,23 +83,21 @@ class Image:
         else:
             self.pixmap_item.setRotation(self.rotation)
 
-        self._scale: float = 1.0
         try:
-            self.scale(
-                get_image_from_storage(
-                    self.image_filename,
-                    ImageKeys.scale,
-                )
+            scale = get_image_from_storage(
+                self.image_filename,
+                ImageKeys.scale,
             )
         except KeyError:
-            new_scale = min(
+            scale_fit_image = min(
                 window_width_px / self.pixmap_item.pixmap().width(),
                 window_height_px / self.pixmap_item.pixmap().height(),
             )
-            if new_scale < 1.0:
-                self.scale(new_scale)
+            if scale_fit_image < 1.0:
+                self.scale(scale_fit_image)
         else:
-            global_event_dispatcher.dispatch_event(EventKeys.change_scale, self._scale)
+            self.scale(scale)
+            global_event_dispatcher.dispatch_event(EventKeys.change_scale, scale)
 
         try:
             position = get_image_from_storage(

--- a/battle_map_tv/image.py
+++ b/battle_map_tv/image.py
@@ -26,7 +26,9 @@ class CustomGraphicsPixmapItem(QGraphicsPixmapItem):
         self.setTransformOriginPoint(pixmap.width() / 2, pixmap.height() / 2)
 
     def wheelEvent(self, event):
-        self.set_scale(self.scale() + event.delta() / 1500)
+        value = self.scale() + event.delta() / 1500
+        self.set_scale(value)
+        global_event_dispatcher.dispatch_event(EventKeys.change_scale, value)
 
     def mouseReleaseEvent(self, event):
         super().mouseReleaseEvent(event)
@@ -48,7 +50,6 @@ class CustomGraphicsPixmapItem(QGraphicsPixmapItem):
 
     def set_scale(self, value: float):
         self.setScale(value)
-        global_event_dispatcher.dispatch_event(EventKeys.change_scale, value)
         set_image_in_storage(self.image_filename, ImageKeys.scale, value)
 
 

--- a/battle_map_tv/ui_elements.py
+++ b/battle_map_tv/ui_elements.py
@@ -19,10 +19,16 @@ def get_window_icon():
 
 
 class StyledLineEdit(QLineEdit):
-    def __init__(self, max_length: int, placeholder: str, *args, **kwargs):
+    def __init__(
+        self, max_length: int, width: int, placeholder: str = "", value: str = "", *args, **kwargs
+    ):
         super().__init__(*args, **kwargs)
         self.setMaxLength(max_length)
-        self.setPlaceholderText(placeholder)
+        self.setFixedWidth(width)
+        if placeholder:
+            self.setPlaceholderText(placeholder)
+        if value:
+            self.setText(value)
         self.setStyleSheet(
             """
             QLineEdit {

--- a/battle_map_tv/ui_elements.py
+++ b/battle_map_tv/ui_elements.py
@@ -20,7 +20,13 @@ def get_window_icon():
 
 class StyledLineEdit(QLineEdit):
     def __init__(
-        self, max_length: int, width: int, placeholder: str = "", value: str = "", *args, **kwargs
+        self,
+        max_length: int,
+        width: int,
+        placeholder: str = "",
+        value: str = "",
+        *args,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.setMaxLength(max_length)

--- a/battle_map_tv/window_gui.py
+++ b/battle_map_tv/window_gui.py
@@ -147,10 +147,9 @@ class GuiWindow(QWidget):
 
         slider = DualScaleSlider()
         slider.scale_changed.connect(slider_scale_callback)
-
         container.addWidget(slider)
 
-        global_event_dispatcher.add_handler(EventKeys.change_scale, slider.update_values)
+        global_event_dispatcher.add_handler(EventKeys.change_scale, slider.update_sliders_from_scale)
 
     def add_row_grid(self):
         container = self._create_container()

--- a/battle_map_tv/window_gui.py
+++ b/battle_map_tv/window_gui.py
@@ -149,7 +149,10 @@ class GuiWindow(QWidget):
         slider.scale_changed.connect(slider_scale_callback)
         container.addWidget(slider)
 
-        global_event_dispatcher.add_handler(EventKeys.change_scale, slider.update_sliders_from_scale)
+        global_event_dispatcher.add_handler(
+            event_type=EventKeys.change_scale,
+            handler=slider.update_sliders_from_scale,
+        )
 
     def add_row_grid(self):
         container = self._create_container()

--- a/battle_map_tv/window_gui.py
+++ b/battle_map_tv/window_gui.py
@@ -20,6 +20,7 @@ from battle_map_tv.ui_elements import (
     ColorSelectionWindow,
     FixedRowGridLayout,
 )
+from elements.dual_scale_slider import DualScaleSlider
 from .window_image import ImageWindow
 from .grid import GridOverlayColor
 
@@ -140,31 +141,16 @@ class GuiWindow(QWidget):
     def add_row_scale_slider(self):
         container = self._create_container()
 
-        label = QLabel("Scale")
-        container.addWidget(label)
-
-        slider_factor = 100
-
         def slider_scale_callback(value: int):
             if self.image_window.image is not None:
-                self.image_window.image.scale(normalize_slider_value(value))
+                self.image_window.image.scale(value)
 
-        def normalize_slider_value(value: int) -> float:
-            return max(value, 1) / slider_factor
+        slider = DualScaleSlider()
+        slider.scale_changed.connect(slider_scale_callback)
 
-        slider = StyledSlider(lower=0, upper=4 * slider_factor, default=slider_factor)
-        slider.valueChanged.connect(slider_scale_callback)
-        slider.valueChanged.connect(lambda value: label.setText(str(normalize_slider_value(value))))
         container.addWidget(slider)
 
-        def update_slider_scale_callback(value: float):
-            slider.setValue(int(value * slider_factor))
-
-        global_event_dispatcher.add_handler(EventKeys.change_scale, update_slider_scale_callback)
-
-        label = QLabel(str(slider.value() / slider_factor))
-        label.setMinimumWidth(40)
-        container.addWidget(label)
+        global_event_dispatcher.add_handler(EventKeys.change_scale, slider.update_values)
 
     def add_row_grid(self):
         container = self._create_container()

--- a/battle_map_tv/window_gui.py
+++ b/battle_map_tv/window_gui.py
@@ -143,7 +143,7 @@ class GuiWindow(QWidget):
 
         def slider_scale_callback(value: int):
             if self.image_window.image is not None:
-                self.image_window.image.scale(value)
+                self.image_window.image.scale(value, dispatch_event=False)
 
         slider = DualScaleSlider()
         slider.scale_changed.connect(slider_scale_callback)


### PR DESCRIPTION
Make more fine scaling of images possible by having two sliders: one for coarse adjustments and one for fine adjustments.

This PR also fixes some small issues with callbacks around image scaling.