### PR TITLE
Fix too large images failing

### DIFF
--- a/battle_map_tv/image.py
+++ b/battle_map_tv/image.py
@@ -19,6 +19,8 @@ from battle_map_tv.storage import (
 class CustomGraphicsPixmapItem(QGraphicsPixmapItem):
     def __init__(self, image_path: str):
         pixmap = QPixmap(image_path)
+        if pixmap.isNull():
+            raise ValueError(f"Failed to load '{image_path}'")
         super().__init__(pixmap)
         self.image_filename = os.path.basename(image_path)
         self.setFlag(self.GraphicsItemFlag.ItemIsMovable)
@@ -90,12 +92,7 @@ class Image:
                 ImageKeys.scale,
             )
         except KeyError:
-            scale_fit_image = min(
-                window_width_px / self.pixmap_item.pixmap().width(),
-                window_height_px / self.pixmap_item.pixmap().height(),
-            )
-            if scale_fit_image < 1.0:
-                self.scale(scale_fit_image)
+            self._fit_image_to_window(window_width_px, window_height_px)
         else:
             self.scale(scale)
 
@@ -108,6 +105,12 @@ class Image:
             self.center()
         else:
             self.pixmap_item.set_position(position)
+
+    def _fit_image_to_window(self, window_width_px: int, window_height_px: int):
+        image_width = self.pixmap_item.pixmap().width()
+        image_height = self.pixmap_item.pixmap().height()
+        scale = min(window_width_px / image_width, window_height_px / image_height)
+        self.scale(scale)
 
     def delete(self):
         self.scene.removeItem(self.pixmap_item)

--- a/battle_map_tv/window_image.py
+++ b/battle_map_tv/window_image.py
@@ -1,7 +1,7 @@
 from typing import Optional, Callable
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QMouseEvent
+from PySide6.QtGui import QMouseEvent, QImageReader
 from PySide6.QtWidgets import QGraphicsView, QGraphicsScene
 
 from battle_map_tv.aoe import AreaOfEffectManager
@@ -26,6 +26,8 @@ class ImageWindow(QGraphicsView):
         self.setAlignment(Qt.AlignCenter)  # type: ignore[attr-defined]
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)  # type: ignore[attr-defined]
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)  # type: ignore[attr-defined]
+        # allow for large size images
+        QImageReader.setAllocationLimit(0)
 
         scene = QGraphicsScene()
         scene.setSceneRect(0, 0, self.size().width(), self.size().height())


### PR DESCRIPTION
There was a bug where images above a certain resolution would fail to load. Fix it by disabling a limit on image size.

Also:
- raise an error if the image failed to load
- refactor the part where we fit an image to the screen