### PR TITLE
Fix aoe object tracking

### DIFF
--- a/battle_map_tv/aoe.py
+++ b/battle_map_tv/aoe.py
@@ -45,6 +45,7 @@ class AreaOfEffectManager:
     def cancel(self):
         if self.temp_obj is not None:
             self.temp_obj.remove()
+            self.temp_obj = None
         self.waiting_for = None
         self.start_point = None
         self.callback = None

--- a/battle_map_tv/aoe.py
+++ b/battle_map_tv/aoe.py
@@ -75,8 +75,6 @@ class AreaOfEffectManager:
     def mouse_release_event(self, event: QMouseEvent) -> bool:
         if self.waiting_for is not None:
             assert self.callback
-            if self.temp_obj is not None:
-                self.temp_obj.remove()
             shape_obj = self._create_shape_obj(event=event)
             shape_obj.set_is_movable()
             self._store.append(shape_obj)


### PR DESCRIPTION
Three fixes to how we keep track of AOE objects:

- Clear the `AreaOfEffectManager.temp_obj` attribute when the shape is cancelled.
- When the mouse button is released, we now remove the `temp_obj` twice, fix that and do it only once.
- Make sure when a shape is remove by right mouse click, it's also removed from `AreaOfEffectManager._store`.